### PR TITLE
Pin versions of GitHub Actions to full commit hash

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Setup
-      - uses: actions/checkout@v2
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: ruby/setup-ruby@6e5d382445ae5590b7449d8b3bc8cb1c2c27f617 # v1.317.0
         with:
           bundler-cache: true
       # Test


### PR DESCRIPTION
## What?

This PR pins versions of GitHub Actions to full commit hash by pinact.
In general, this PR doesn't change the behavior of the workflows, so you can merge this safely.

## Why?

A while ago, the popular GitHub Action tj-actions/changed-files action was compromised.

- https://semgrep.dev/blog/2025/popular-github-action-tj-actionschanged-files-is-compromised/
- https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised

All tags were tampered and they pointed to a revision with malicious code.

The issue was solved, but similar issues could happen again.
To avoid this kind of issues, we should pin versions of GitHub Actions.
This is a common practice of GitHub Actions.

https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

> Pin actions to a full length commit SHA
> Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release.
> Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload.
> When selecting a SHA, you should verify it is from the action's repository and not a repository fork.

## How was this pull request created?

This pull request was created by [pinact](https://github.com/suzuki-shunsuke/pinact) and [multi-gitter](https://github.com/lindell/multi-gitter).

## Deadling

We will be turning on a global setting that will ENFORCE that all actions can only use pinned versions, if others are in use, the workflow will fail
## Contact

If you have any question, please ask at the Slack channel #tech-platform
